### PR TITLE
Adds five.py to setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Adds five.py to pypi distribution
+- Adds Travis CI integration
+
 # 0.1.3 - 2016-08-01
 
 - Fixes a bug introduced in 0.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=['six'],
-    py_modules=['named_decorator'],
+    py_modules=['named_decorator', 'five'],
     options={
         'bdist_wheel': {
             'universal': 1,


### PR DESCRIPTION
I need to add "five" to the list of modules, otherwise it doesn't get shipped to pypi. Learned that the hard way trying to use this in yelp-main.

After review I'll create a tag, update CHANGELOG and setup.py, and release to pypi.