### PR TITLE
Fix readme examples to actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ def with_log_and_call(log_message):
         @wraps(method, with_log_and_call)
         def wrapper(*args, **kwargs):
             print(log_message)
-            return method(*args, **kargs)
-    return wrapper
+            return method(*args, **kwargs)
+        return wrapper
+    return outer_wrapper
  ```
 
 You can use the function form if a decorator doesn't suit you:
@@ -37,9 +38,9 @@ def with_log_and_call(log_message):
     def outer_wrapper(method):
         def wrapper(*args, **kwargs):
             print(log_message)
-            return method(*args, **kargs)
+            return method(*args, **kwargs)
         return named_decorator(wrapper, method, with_log_and_call)
-    return wrapper
+    return outer_wrapper
 ```
 
 In both examples, the `wrapper` function returned by the decorator will be renamed to


### PR DESCRIPTION
Addresses #12 

First example:
```python
from named_decorator import wraps

def with_log_and_call(log_message):
    def outer_wrapper(method):
        @wraps(method, with_log_and_call)
        def wrapper(*args, **kwargs):
            print(log_message)
            return method(*args, **kwargs)
        return wrapper
    return outer_wrapper

@with_log_and_call('Message!')
def f(a, b):
    print(a, b)

f('a', 'b')  # prints "Message!\n('a', 'b')"
```

Second example:
```python
from named_decorator import named_decorator

def with_log_and_call(log_message):
    def outer_wrapper(method):
        def wrapper(*args, **kwargs):
            print(log_message)
            return method(*args, **kwargs)
        return named_decorator(wrapper, method, with_log_and_call)
    return outer_wrapper

@with_log_and_call('Messageff')
def g(a, b):
    print(a, b)

g('f', 'g')  # prints "Messageff\n('f', 'g')"
```